### PR TITLE
Add SSH keep-alive options to Pantheon rsync commands

### DIFF
--- a/assets/providers/pantheon.yaml
+++ b/assets/providers/pantheon.yaml
@@ -82,7 +82,7 @@ files_pull_command:
     PANTHEON_ARRAY=( $PANTHEON_INFO )
     PANTHEON_UUID=${PANTHEON_ARRAY[0]}
     echo "${BOLD}Downloading files from Pantheon...${NORM}"
-    rsync -rLvz --copy-unsafe-links --size-only --ipv4 --progress --exclude="/php" --exclude="/styles" --exclude="/css" --exclude="/js" --exclude="/webform" --include="*/" --include="*.jpg" --include="*.jpeg" --include="*.gif" --include="*.png" --include="*.svg" --include="*.eot" --include="*.ttf" --include="*.woff" --include="*.woff2" --include="*.json" --include="*.css" --include="/exo-file/*" --exclude="*" -e 'ssh -p 2222' "$PANTHEON_ENV.$PANTHEON_UUID@appserver.$PANTHEON_ENV.$PANTHEON_UUID.drush.in:files/" /var/www/html/web/sites/default/files
+    rsync -rLvz --copy-unsafe-links --size-only --ipv4 --progress --exclude="/php" --exclude="/styles" --exclude="/css" --exclude="/js" --exclude="/webform" --include="*/" --include="*.jpg" --include="*.jpeg" --include="*.gif" --include="*.png" --include="*.svg" --include="*.eot" --include="*.ttf" --include="*.woff" --include="*.woff2" --include="*.json" --include="*.css" --include="/exo-file/*" --exclude="*" -e 'ssh -p 2222 -o ServerAliveInterval=60 -o ServerAliveCountMax=10' "$PANTHEON_ENV.$PANTHEON_UUID@appserver.$PANTHEON_ENV.$PANTHEON_UUID.drush.in:files/" /var/www/html/web/sites/default/files
 
 files_import_command:
   command: |
@@ -133,4 +133,4 @@ files_push_command:
     PANTHEON_ARRAY=( $PANTHEON_INFO )
     PANTHEON_UUID=${PANTHEON_ARRAY[0]}
     echo "${BOLD}Uploading files to Pantheon...${NORM}"
-    rsync -rLvz --size-only --ipv4 --progress --exclude="/php" --exclude="/styles" --exclude="/css" --exclude="/js" -e 'ssh -p 2222' "/var/www/html/web/sites/default/files/." --temp-dir=~/tmp/ "$PANTHEON_ENV.$PANTHEON_UUID@appserver.$PANTHEON_ENV.$PANTHEON_UUID.drush.in:files/"
+    rsync -rLvz --size-only --ipv4 --progress --exclude="/php" --exclude="/styles" --exclude="/css" --exclude="/js" -e 'ssh -p 2222 -o ServerAliveInterval=60 -o ServerAliveCountMax=10' "/var/www/html/web/sites/default/files/." --temp-dir=~/tmp/ "$PANTHEON_ENV.$PANTHEON_UUID@appserver.$PANTHEON_ENV.$PANTHEON_UUID.drush.in:files/"


### PR DESCRIPTION
- Add ServerAliveInterval=60 and ServerAliveCountMax=10 to prevent SSH connection timeouts
- Applied to both files_pull_command and files_push_command rsync operations